### PR TITLE
added mask of ones, if no mask is given

### DIFF
--- a/skued/image/indexing.py
+++ b/skued/image/indexing.py
@@ -49,6 +49,8 @@ def bragg_peaks(im, mask=None, center=None, min_dist=None):
     Liu, Lai Chung. Chemistry in Action: Making Molecular Movies with Ultrafast
     Electron Diffraction and Data Science, Chapter 2. Springer Nature, 2020.
     """
+    if mask is None:
+        mask = np.ones(im.shape)    
     if center is None:
         center = autocenter(im=im, mask=mask)
 

--- a/skued/image/indexing.py
+++ b/skued/image/indexing.py
@@ -50,7 +50,7 @@ def bragg_peaks(im, mask=None, center=None, min_dist=None):
     Electron Diffraction and Data Science, Chapter 2. Springer Nature, 2020.
     """
     if mask is None:
-        mask = np.ones(im.shape)    
+        mask = np.ones(im.shape)
     if center is None:
         center = autocenter(im=im, mask=mask)
 

--- a/skued/image/tests/test_indexing.py
+++ b/skued/image/tests/test_indexing.py
@@ -47,3 +47,21 @@ def test_bragg_peaks():
     peaks = bragg_peaks(I, mask=np.ones_like(I, dtype=bool))
 
     assert len(peaks) == len(in_plane_refls)
+
+
+def test_bragg_peaks_no_mask():
+    """Test that the `bragg_peaks` function finds all Bragg peaks, without supplying a mask file."""
+    kx, ky, I, cryst = diff_pattern_sc()
+    kk = np.sqrt(kx**2 + ky**2)
+
+    # only in-plane refls (hk0) and not (000)
+    # Also, some reflections will appear at the edge of the frame
+    in_plane_refls = [
+        refl
+        for refl in cryst.bounded_reflections(kk.max())
+        if (refl[2] == 0 and np.abs(cryst.scattering_vector(refl)[0]) < kx.max())
+    ]
+
+    peaks = bragg_peaks(I)
+
+    assert len(peaks) == len(in_plane_refls)


### PR DESCRIPTION
if mask is None, you will get an IndexError from scikit-image. This is because `arr1` and `arr2` will have different shapes than `m1` and `m2`.

```python3
def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
                           overlap_ratio=0.3):
    """
    Masked normalized cross-correlation between arrays.

    Parameters
    ----------
    arr1 : ndarray
        First array.
    arr2 : ndarray
        Seconds array. The dimensions of `arr2` along axes that are not
        transformed should be equal to that of `arr1`.
    m1 : ndarray
        Mask of `arr1`. The mask should evaluate to `True`
        (or 1) on valid pixels. `m1` should have the same shape as `arr1`.
    m2 : ndarray
        Mask of `arr2`. The mask should evaluate to `True`
        (or 1) on valid pixels. `m2` should have the same shape as `arr2`.
    mode : {'full', 'same'}, optional
        'full':
            This returns the convolution at each point of overlap. At
            the end-points of the convolution, the signals do not overlap
            completely, and boundary effects may be seen.
        'same':
            The output is the same size as `arr1`, centered with respect
            to the `‘full’` output. Boundary effects are less prominent.
    axes : tuple of ints, optional
        Axes along which to compute the cross-correlation.
    overlap_ratio : float, optional
        Minimum allowed overlap ratio between images. The correlation for
        translations corresponding with an overlap ratio lower than this
        threshold will be ignored. A lower `overlap_ratio` leads to smaller
        maximum translation, while a higher `overlap_ratio` leads to greater
        robustness against spurious matches due to small overlap between
        masked images.

    Returns
    -------
    out : ndarray
        Masked normalized cross-correlation.

    Raises
    ------
    ValueError : if correlation `mode` is not valid, or array dimensions along
        non-transformation axes are not equal.

    References
    ----------
    .. [1] Dirk Padfield. Masked Object Registration in the Fourier Domain.
           IEEE Transactions on Image Processing, vol. 21(5),
           pp. 2706-2718 (2012). :DOI:`10.1109/TIP.2011.2181402`
    .. [2] D. Padfield. "Masked FFT registration". In Proc. Computer Vision and
           Pattern Recognition, pp. 2918-2925 (2010).
           :DOI:`10.1109/CVPR.2010.5540032`
    """
```
[source](https://github.com/scikit-image/scikit-image/blob/b8ce4d0c2c65684b131870abfe60228136108d4e/skimage/registration/_masked_phase_cross_correlation.py#L99-L153)