### PR TITLE
improved masking for `bragg_peaks_persistence`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Release 2.1.12
+--------------
+
+* Improved the masking functionality in `bragg_peaks_persistence`.
+
 Release 2.1.11
 --------------
 

--- a/skued/__init__.py
+++ b/skued/__init__.py
@@ -2,7 +2,7 @@
 __author__ = "Laurent P. René de Cotret"
 __email__ = "laurent.renedecotret@mail.mcgill.ca"
 __license__ = "GPLv3"
-__version__ = "2.1.10"
+__version__ = "2.1.12"
 
 from .affine import (
     affine_map,

--- a/skued/image/indexing.py
+++ b/skued/image/indexing.py
@@ -237,11 +237,17 @@ def bragg_peaks_persistence(
     birth_death = np.array(birth_death).reshape(-1, 2)
 
     # remove peaks that are within the masked area
-    if mask.sum() != mask.shape[0]*mask.shape[1]:
+    if mask.sum() != mask.shape[0] * mask.shape[1]:
         peaks = np.array([p for p in peaks if mask[p[1], p[0]]])
-        birth_death= np.array([bd for p, bd in zip(peaks, birth_death) if mask[p[1], p[0]]])
-        birth_death_indices= np.array([bdi for p, bdi in zip(peaks, birth_death_indices) if mask[p[1], p[0]]])
-        persistencies= np.array([pers for p, pers in zip(peaks, persistencies) if mask[p[1], p[0]]])
+        birth_death = np.array(
+            [bd for p, bd in zip(peaks, birth_death) if mask[p[1], p[0]]]
+        )
+        birth_death_indices = np.array(
+            [bdi for p, bdi in zip(peaks, birth_death_indices) if mask[p[1], p[0]]]
+        )
+        persistencies = np.array(
+            [pers for p, pers in zip(peaks, persistencies) if mask[p[1], p[0]]]
+        )
     return peaks, birth_death, birth_death_indices, persistencies
 
 

--- a/skued/image/indexing.py
+++ b/skued/image/indexing.py
@@ -190,10 +190,8 @@ def bragg_peaks_persistence(
     """
     if mask is None:
         mask = np.ones_like(im, dtype=bool)
-    im[~mask] = 0.0
     if center is None:
         center = autocenter(im=im, mask=mask)
-    image = im
 
     g0 = Persistence(im).persistence
     birth_death = list()
@@ -237,6 +235,13 @@ def bragg_peaks_persistence(
         sorted(candidates, key=lambda p: np.linalg.norm(p - center))
     ).reshape(-1, 2)
     birth_death = np.array(birth_death).reshape(-1, 2)
+
+    # remove peaks that are within the masked area
+    if mask.sum() != mask.shape[0]*mask.shape[1]:
+        peaks = np.array([p for p in peaks if mask[p[1], p[0]]])
+        birth_death= np.array([bd for p, bd in zip(peaks, birth_death) if mask[p[1], p[0]]])
+        birth_death_indices= np.array([bdi for p, bdi in zip(peaks, birth_death_indices) if mask[p[1], p[0]]])
+        persistencies= np.array([pers for p, pers in zip(peaks, persistencies) if mask[p[1], p[0]]])
     return peaks, birth_death, birth_death_indices, persistencies
 
 


### PR DESCRIPTION
In the function `bragg_peaks_persistence` from @trbritt the hard edges of the mask are resulting in peaks being detected at those edges. I propose to scan the full image for peaks and throw away the peaks that are in the masked area later. Resulted in improved results on my end. `autocenter` is still done with the mask in place.